### PR TITLE
Fixes the broken repository field value

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-navigation-switch-transitioner",
   "version": "0.0.8",
   "description": "A react-navigation transitioner and switch navigator using it",
-  "repository": "https://https://github.com/elyalvarado/react-navigation-switch-transitioner",
+  "repository": "github:elyalvarado/react-navigation-switch-transitioner",
   "author": "Ely Alvarado",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
The value in the repository field has `https://` duplicated and causes the repository link on the [npm package page](https://www.npmjs.com/package/react-navigation-switch-transitioner) to be broken.